### PR TITLE
GF-6936: On-device source packaging support

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -16,10 +16,8 @@
 	 */
 	function loadFiles(context, paths, results, params, callback) {
 		if (paths.length > 0) {
-			var libRoot = enyo.path.rewrite("$lib");
 			var path = paths.shift();
-			var file = libRoot + "enyo-ilib/ilib/locale/" + path;
-			var ajax = new enyo.Ajax({url: file});
+			var ajax = new enyo.Ajax({url: enyo.path.rewrite("$lib/enyo-ilib/ilib/locale/" + path)});
 			//console.log("moondemo2: browser/async: attempting to load lib/enyo-ilib/ilib/locale/" + path);
 			var resultFunc = function(inSender, json) {
 				//console.log("moondemo2: " + (json ? "success" : "failed"));
@@ -53,9 +51,8 @@
 			// synchronous
 			paths.forEach(function (path) {
 				// console.log("browser/sync: attempting to load lib/enyo-ilib/ilib/locale/" + path);
-				var libRoot = enyo.path.rewrite("$lib");
 				var ajax = new enyo.Ajax({
-					url: libRoot + "enyo-ilib/ilib/locale/" + path,
+					url: enyo.path.rewrite("$lib/enyo-ilib/ilib/locale/" + path),
 					sync: true
 				});
 


### PR DESCRIPTION
This pull request is part of a series, with a pre-requisite of enyojs/enyo#324, and should not be merged until the enyo pull request is merged.

Minor change to rewrite the entire path, not just $lib, so that the library path can be redirected when packaging to use onDeviceSource.
