### PR TITLE
GF-12831: TypeError while loading strings.

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -138,6 +138,9 @@
  */
 $L = (function() {
 	var lfunc = function (string) {
+		if (!$L.rb) {
+			return string;
+		}
 		var str = $L.rb.getString(string);
 		return str.toString();
 	};
@@ -146,6 +149,7 @@ $L = (function() {
 		type: "html",
 		name: "strings",
 		missing: locale.getLanguage() === "en" ? "source" : "pseudo",
+		sync: true,
 		lengthen: true		// if pseudo-localizing, this tells it to lengthen strings
 	});
 	return lfunc;
@@ -161,6 +165,7 @@ $L.setLocale = function (spec) {
 			locale: spec,
 			type: "html",
 			name: "strings",
+			sync: true,
 			missing: locale.getLanguage() === "en" ? "source" : "pseudo",
 			lengthen: true		// if pseudo-localizing, this tells it to lengthen strings
 		});


### PR DESCRIPTION
Avoid using undefined objects to load strings inside of the
$L function. In some circumstances, the resource bundle is not
ready yet, and the call to $L.rb.getString will fail with a
TypeError because $L.rb is not defined yet. This puts in some
defensive code to guard against that. Instead, the string
parameter (in English probably) will be returned as-is.
