### PR TITLE
GF-14590: adds rtl property on enyo.Control

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -109,6 +109,9 @@
 		var script = new ilib.ScriptInfo(li.getDefaultScript());
 		if (script.getScriptDirection() === "rtl") {
 			enyo.dom.getFirstElementByTagName("body").className += base + "right-to-left";
+			if (enyo.Control) {
+				enyo.Control.prototype.rtl = true;
+			}
 		}
 
 		// allow enyo or the apps to give CSS classes that are specific to the language, country, or script


### PR DESCRIPTION
When the UI locale is a right-to-left language, the glue code
now puts an rtl property set to true onto the enyo.Control
prototype. This way, all of the widgets can easily detect if
they are in rtl mode without doing the expensive operation of
checking the CSS class.
