### PR TITLE
GF-7388: Let enyo-ilib (rather then enyo core) broadcast the "onlocalechange" sig...

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -181,6 +181,6 @@ $L.setLocale = function (spec) {
  * `onlocalechange` signal.
  */
 enyo.updateLocale = function() {
-	ilib.setLocale(navigator.$language);
+	ilib.setLocale(navigator.language);
 }
 


### PR DESCRIPTION
...nal, so that ilib can set its locale before any locale-aware Enyo controls try to query it. Addresses GF-7388.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
