### PR TITLE
Update to 20130919-build-3.0-002 of ilib

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -142,10 +142,24 @@
  */
 $L = (function() {
 	var lfunc = function (string) {
-		if (!$L.rb) {
-			return string;
+		var str;
+		if (typeof(string) === 'string') {
+			if (!$L.rb) {
+				return string;
+			}
+			str = $L.rb.getString(string);
+		} else if (typeof(string) === 'object') {
+			if (typeof(string.key) !== 'undefined' && typeof(string.value) !== 'undefined') {
+				if (!$L.rb) {
+					return string.value;
+				}
+				str = $L.rb.getString(string.value, string.key);
+			} else {
+				str = "";
+			}
+		} else {
+			str = string;
 		}
-		var str = $L.rb.getString(string);
 		return str.toString();
 	};
 	var locale = new ilib.Locale();

--- a/ilib/js/ilib-dyn-standard.js
+++ b/ilib/js/ilib-dyn-standard.js
@@ -29,7 +29,7 @@ var ilib = ilib || {};
  */
 ilib.getVersion = function () {
     // increment this for each release
-    return "2.0";
+    return "3.0";
 };
 
 /**
@@ -1200,7 +1200,7 @@ ilib.isEmpty = function (obj) {
 	}
 	
 	for (prop in obj) {
-		if (prop && obj[prop]) {
+		if (prop && typeof(obj[prop]) !== 'undefined') {
 			return false;
 		}
 	}
@@ -1701,9 +1701,11 @@ ilib.String.prototype = {
 	format: function (params) {
 		var formatted = this.str;
 		if (params) {
+			var regex;
 			for (var p in params) {
 				if (typeof(params[p]) !== 'undefined') {
-					formatted = formatted.replace("\{"+p+"\}", params[p]);
+					regex = new RegExp("\{"+p+"\}", "g");
+					formatted = formatted.replace(regex, params[p]);
 				}
 			}
 		}
@@ -7083,7 +7085,7 @@ ilib.DateRngFmt.prototype = {
  * @namespace
  * Provides a set of static routines that return information about characters.
  * These routines emulate the C-library ctype functions. The characters must be 
- * encoded in utf-8, as no other charsets are currently supported. Only the first
+ * encoded in utf-16, as no other charsets are currently supported. Only the first
  * character of the given string is tested.
  */
 ilib.CType = {
@@ -7162,8 +7164,8 @@ ilib.CType = {
 	/**
 	 * Return whether or not the first character is within the named range
 	 * of Unicode characters. The valid list of range names are taken from 
-	 * the Unicode 6.0 spec. Only those ranges which have characters in the 
-	 * Basic Multilingual Plane (BMP) are supported. Currently, this method 
+	 * the Unicode 6.0 spec. Characters in all ranges of Unicode are supported,
+	 * including those supported in Javascript via UTF-16. Currently, this method 
 	 * supports the following range names:
 	 * 
 	 * <ul>
@@ -8868,6 +8870,198 @@ ilib.DurFmt.prototype.getStyle = function () {
 	return this.style;
 };
 
+/*
+ * scriptinfo.js - information about scripts
+ * 
+ * Copyright © 2012-2013, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// !depends ilibglobal.js
+
+// !data scripts
+
+/**
+ * @class
+ * Create a new script info instance. This class encodes information about
+ * scripts, which are sets of characters used in a writing system.<p>
+ * 
+ * The options object may contain any of the following properties:
+ * 
+ * <ul>
+ * <li><i>onLoad</i> - a callback function to call when the script info object is fully 
+ * loaded. When the onLoad option is given, the script info object will attempt to
+ * load any missing locale data using the ilib loader callback.
+ * When the constructor is done (even if the data is already preassembled), the 
+ * onLoad function is called with the current instance as a parameter, so this
+ * callback can be used with preassembled or dynamic loading or a mix of the two.
+ * 
+ * <li><i>sync</i> - tell whether to load any missing locale data synchronously or 
+ * asynchronously. If this option is given as "false", then the "onLoad"
+ * callback must be given, as the instance returned from this constructor will
+ * not be usable for a while. 
+ *
+ * <li><i>loadParams</i> - an object containing parameters to pass to the 
+ * loader callback function when locale data is missing. The parameters are not
+ * interpretted or modified in any way. They are simply passed along. The object 
+ * may contain any property/value pairs as long as the calling code is in
+ * agreement with the loader callback function as to what those parameters mean.
+ * </ul>
+ * 
+ * Depends directive: !depends scriptinfo.js
+ * 
+ * @constructor
+ * @param {string} script The ISO 15924 4-letter identifier for the script
+ * @param {Object} options parameters to initialize this matcher 
+ */
+ilib.ScriptInfo = function(script, options) {
+	var sync = true,
+	    loadParams = undefined;
+	
+	this.script = script;
+	
+	if (options) {
+		if (typeof(options.sync) !== 'undefined') {
+			sync = (options.sync == true);
+		}
+		
+		if (typeof(options.loadParams) !== 'undefined') {
+			loadParams = options.loadParams;
+		}
+	}
+
+	if (!ilib.ScriptInfo.cache) {
+		ilib.ScriptInfo.cache = {};
+	}
+
+	if (!ilib.data.scripts) {
+		ilib.loadData({
+			object: ilib.ScriptInfo, 
+			locale: "-", 
+			name: "scripts.json", 
+			sync: sync, 
+			loadParams: loadParams, 
+			callback: ilib.bind(this, function (info) {
+				if (!info) {
+					info = {"Latn":{"nb":215,"nm":"Latin","lid":"Latin","rtl":false,"ime":false,"casing":true}};
+					var spec = this.locale.getSpec().replace(/-/g, "_");
+					ilib.ScriptInfo.cache[spec] = info;
+				}
+				ilib.data.scripts = info;
+				this.info = script && ilib.data.scripts[script];
+				if (options && typeof(options.onLoad) === 'function') {
+					options.onLoad(this);
+				}
+			})
+		});
+	} else {
+		this.info = ilib.data.scripts[script];
+	}
+
+};
+
+/**
+ * @static
+ * Return an array of all ISO 15924 4-letter identifier script identifiers that
+ * this copy of ilib knows about.
+ * @return {Array.<string>} an array of all script identifiers that this copy of
+ * ilib knows about
+ */
+ilib.ScriptInfo.getAllScripts = function() {
+	var ret = [],
+		script = undefined,
+		scripts = ilib.data.scripts;
+	
+	for (script in scripts) {
+		if (script && scripts[script]) {
+			ret.push(script);
+		}
+	}
+	
+	return ret;
+};
+
+ilib.ScriptInfo.prototype = {
+	/**
+	 * Return the 4-letter ISO 15924 identifier associated
+	 * with this script.
+	 * @return {string} the 4-letter ISO code for this script
+	 */
+	getCode: function () {
+		return this.info && this.script;
+	},
+	
+	/**
+	 * Get the ISO 15924 code number associated with this
+	 * script.
+	 * 
+	 * @return {number} the ISO 15924 code number
+	 */
+	getCodeNumber: function () {
+		return this.info && this.info.nb || 0;
+	},
+	
+	/**
+	 * Get the name of this script in English.
+	 * 
+	 * @return {string} the name of this script in English
+	 */
+	getName: function () {
+		return this.info && this.info.nm;
+	},
+	
+	/**
+	 * Get the long identifier assciated with this script.
+	 * 
+	 * @return {string} the long identifier of this script
+	 */
+	getLongCode: function () {
+		return this.info && this.info.lid;
+	},
+	
+	/**
+	 * Return the usual direction that text in this script is written
+	 * in. Possible return values are "rtl" for right-to-left,
+	 * "ltr" for left-to-right, and "ttb" for top-to-bottom.
+	 * 
+	 * @return {string} the usual direction that text in this script is
+	 * written in
+	 */
+	getScriptDirection: function() {
+		return (this.info && typeof(this.info.rtl) !== 'undefined' && this.info.rtl) ? "rtl" : "ltr";
+	},
+	
+	/**
+	 * Return true if this script typically requires an input method engine
+	 * to enter its characters.
+	 * 
+	 * @return {boolean} true if this script typically requires an IME
+	 */
+	getNeedsIME: function () {
+		return this.info && this.info.ime ? true : false; // converts undefined to false
+	},
+	
+	/**
+	 * Return true if this script uses lower- and upper-case characters.
+	 * 
+	 * @return {boolean} true if this script uses letter case
+	 */
+	getCasing: function () {
+		return this.info && this.info.casing ? true : false; // converts undefined to false
+	}
+};
 /**
  * @license
  * Copyright © 2012-2013, JEDLSoft
@@ -8908,4 +9102,5 @@ durfmt.js
 resources.js
 localeinfo.js
 daterangefmt.js
+scriptinfo.js
 */

--- a/nodeglue.js
+++ b/nodeglue.js
@@ -85,7 +85,24 @@ exports.ilib._load = (function () {
 
 exports.$L = (function() {
 	var lfunc = function (string) {
-		var str = $L.rb.getString(string); 
+		var str;
+		if (typeof(string) === 'string') {
+			if (!$L.rb) {
+				return string;
+			}
+			str = $L.rb.getString(string);
+		} else if (typeof(string) === 'object') {
+			if (typeof(string.key) !== 'undefined' && typeof(string.value) !== 'undefined') {
+				if (!$L.rb) {
+					return string.value;
+				}
+				str = $L.rb.getString(string.value, string.key);
+			} else {
+				str = "";
+			}
+		} else {
+			str = string;
+		}
 		return str.toString();
 	};
 	lfunc.rb = new exports.ilib.ResBundle({


### PR DESCRIPTION
Bug fixes:

[GF-9451] ilib.String.format was only replacing the first occurrence of {var
[GF-9405] ilib.isEmpty returned true if an object had properties but every p
[GF12790] Cannot specify unique keys for strings using the $L function
