### PR TITLE
GF-43376 - update locale settings at library load

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -207,3 +207,6 @@ enyo.updateLocale = function() {
 	enyo.updateI18NClasses();
 };
 
+// we go ahead and run this once during loading of iLib settings are valid
+// during the loads of later libraries.
+enyo.updateLocale();


### PR DESCRIPTION
We had mistakenly taken out the code that would set body
classses at startup when adapting enyo-ilib to work with the
webOS app container.  Before, this code was run in the
context of enyo.ready(), but it really should just be run
immediately since we need a good ilib context before any
localized libraries are loaded.

This won't be a problem for container-based apps -- they
already are resetting the string catalog at startup,
and if body classes are doubled, that's no problems as the
enyo.dom.addClass code ensures that class names aren't
duplicated.  There won't be conflicting class names
as the container reloads itself on locale changes that
happen before the container assumes an application identify.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
