### PR TITLE
GF-52704: remove default pseudo-localization

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -196,7 +196,6 @@ $L.setLocale = function (spec) {
 			type: "html",
 			name: "strings",
 			sync: true,
-			missing: locale.getLanguage() === "en" ? "source" : "pseudo",
 			lengthen: true		// if pseudo-localizing, this tells it to lengthen strings
 		});
 	}


### PR DESCRIPTION
For development, we made all strings that do not have translations
appear as pseudo-translated so that QA can tell the difference
between a translated string, a string which is ready for translation
but for which the translation is not yet complete, and a string that
is not ready for translation at all. This pseudo-localization is
confusing many people and they are submitting bugs about "garbage
translations", despite our efforts to educate them. So, we are
removing this default pseudo-localization and instead only using a
particular locale for pseudo testing. (We will pick eu-ES, Basque
for Spain.)

Enyo-DCO-1.1-Signed-Off-By: Edwin Hoogerbeets (edwin.hoogerbeets@lge.com)
