### PR TITLE
GF-54530: avoid "ransom note" fonts

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -109,10 +109,11 @@
             document.body.className = document.body.className.replace(new RegExp('(^|\\s)'+ base +'[^\\s]*', 'g'), '');
         }
 
-		var scriptName = li.getScript(); 
-		if (scriptName !== "Latn" || locale.getLanguage() === "vi") {
-			// allow enyo to define other fonts for non-Latin languages, or Vietnamese which
-			// is Latin-based, but the characters with multiple accents don't appear in the
+        var nonLatinLanguages = ["cs", "hu", "lv", "lt", "po", "ro", "sr", "sl", "tr", "vi"];
+		var scriptName = li.getScript();
+		if (scriptName !== "Latn" || nonLatinLanguages.indexOf(locale.getLanguage()) !== -1) {
+			// allow enyo to define other fonts for non-Latin languages, or for certain
+			// Latin-based languages where the characters with some accents don't appear in the
 			// regular fonts, creating a strange "ransom note" look with a mix of fonts in the
 			// same word. So, treat it like a non-Latin language in order to get all the characters
 			// to display with the same font.


### PR DESCRIPTION
This change puts the enyo-locale-non-latin class on the body tag for every
language that has missing glyphs in either Miso or Museo Sans. This code
should be updated when we get newer versions of those fonts. The languages
with missing glyphs are:

cs Czech
hu Hungarian
lv Latvian
lt Lithuanian
po Polish
ro Romanian
sr Serbian
sl Slovakian
tr Turkish
vi Vietnamese

Enyo-DCO-1.1-Signed-Off-By: Edwin Hoogerbeets (edwin.hoogerbeets@lge.com)
