### PR TITLE
GF-56619: fix ISO code for Polish

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -110,7 +110,7 @@
         }
 
         // We use the non-latin fonts for these languages (even though their scripts are technically considered latin)
-        var nonLatinLanguageOverrides = ["cs", "hu", "lv", "lt", "po", "ro", "sr", "sl", "tr", "vi"];
+        var nonLatinLanguageOverrides = ["cs", "hu", "lv", "lt", "pl", "ro", "sr", "sl", "tr", "vi"];
         // We use the latin fonts (with non-Latin fallback) for these languages (even though their scripts are non-latin)
         var latinLanguageOverrides = ["ko"];
 		var scriptName = li.getScript();


### PR DESCRIPTION
The code had "po" for Polish, but the ISO 639 code for Polish is
actually "pl". This bug causes Polish to appear in the UI with
Miso/Museo Sans instead of LG Display because the
enyo-locale-non-latin CSS class is not placed on the body tag
properly.
