### PR TITLE
allow caching of json files

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -21,7 +21,7 @@
 		}
 		if (paths.length > 0) {
 			var path = paths.shift();
-			var ajax = new enyo.Ajax({url: enyo.path.rewrite("$lib/enyo-ilib/ilib/locale/" + path)});
+			var ajax = new enyo.Ajax({url: enyo.path.rewrite("$lib/enyo-ilib/ilib/locale/" + path), cacheBust: false});
 			//console.log("moondemo2: browser/async: attempting to load lib/enyo-ilib/ilib/locale/" + path);
 			var resultFunc = function(inSender, json) {
                 // console.log("moondemo2: " + (!inSender.failed && json ? "success" : "failed"));
@@ -39,7 +39,7 @@
 				// not there? Try the standard place instead
 				var file = root + path;
 				// console.log("moondemo2: browser/async: attempting to load " + file);
-				var ajax2 = new enyo.Ajax({url: file});
+				var ajax2 = new enyo.Ajax({url: file, cacheBust: false});
 
 				ajax2.response(this, resultFunc);
 				ajax2.error(this, resultFunc);
@@ -61,7 +61,7 @@
 				// console.log("browser/sync: attempting to load lib/enyo-ilib/ilib/locale/" + path);
 				var ajax = new enyo.Ajax({
 					url: enyo.path.rewrite("$lib/enyo-ilib/ilib/locale/" + path),
-					sync: true
+					sync: true, cacheBust: false
 				});
 
 				var handler = function(inSender, json) {
@@ -73,7 +73,7 @@
 					// console.log("browser/sync: Now attempting to load " + root + path);
 					var ajax2 = new enyo.Ajax({
 						url: root + path,
-						sync: true
+						sync: true, cacheBust: false
 					});
 					ajax2.response(this, handler);
 					ajax2.error(this, handler);


### PR DESCRIPTION
ilib performs quite a number of GET requests to JSON files (strings, plurals, localeinfo). Since enyo.Ajax is used, each of these GET requests is performed with a random query string appended in order to prevent cache usage. While this might be a good idea for Ajax requests in general, this makes no sense for the ilib json files - their cache behaviour has to be identical to the application javascript files. This patch deactivates the cacheBust feature of all Ajax requests in glue.js.
