### PR TITLE
WEBOSLCD13-43313: add Croation to non-latin

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -110,7 +110,7 @@
         }
 
         // We use the non-latin fonts for these languages (even though their scripts are technically considered latin)
-        var nonLatinLanguageOverrides = ["cs", "hu", "lv", "lt", "pl", "ro", "sr", "sl", "tr", "vi"];
+        var nonLatinLanguageOverrides = ["bs", "cs", "hr", "hu", "lv", "lt", "pl", "ro", "sr", "sl", "tr", "vi"];
         // We use the latin fonts (with non-Latin fallback) for these languages (even though their scripts are non-latin)
         var latinLanguageOverrides = ["ko"];
 		var scriptName = li.getScript();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "enyo-ilib",
-	"version": "2.0-017",
+	"version": "5.0-001",
 	"main": "./nodeglue.js",
 	"description": "iLib plugin for enyo. iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
 	"keywords": [


### PR DESCRIPTION
Adds Croation and Bosnian to the list of languages that use characters that have glyphs that are missing in Miso/Museo. These languages should get get the enyo-locale-non-latin CSS class on the body tags so that they use LG Display instead.
