### PR TITLE
Corrected a flaw in input-checking logic of toLowerCase and toUpperCase.

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -221,16 +221,16 @@ enyo.setCaseMappers = function() {
  * that call iLib's locale-safe case mapper.
  */
 enyo.toLowerCase = function(inString) {
-	if (typeof(inString) === "undefined" || inString === null) {
-		return inString;
+	if (inString != null) {
+		return enyo.toLowerCase.mapper.map(inString);
 	}
-	return enyo.toLowerCase.mapper.map(inString);
+	return inString;
 };
 enyo.toUpperCase = function(inString) {
-	if (typeof(inString) === "undefined" || inString === null) {
-		return inString;
+	if (inString != null) {
+		return enyo.toUpperCase.mapper.map(inString);
 	}
-	return enyo.toUpperCase.mapper.map(inString);
+	return inString;
 };
 
 /**


### PR DESCRIPTION
This PR is unrelated to any bug tickets, but is just something I noticed.

``` js
inString = null
// null
typeof(inString) === "null"
// false
inString === null
// true
```

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
