### PR TITLE
Added onLocaleChange event to fire when running enyo.updateLocale()

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -241,14 +241,14 @@ enyo.toUpperCase = function(inString) {
  * that locale immediately. Provide nothing, and reset the locale back to the
  * browser's default language.
  */
-enyo.updateLocale = function(inLocale, inPreventEvent) {
-	ilib.setLocale(inLocale || navigator.language);
-	$L.setLocale(inLocale || navigator.language);
-	enyo.updateI18NClasses();
-	if (!inPreventEvent) {
-		enyo.Signals.send("onlocalechange");
-	}
-};
+(function(originalUpdateLocale) {
+	enyo.updateLocale = function(inLocale) {
+		ilib.setLocale(inLocale || navigator.language);
+		$L.setLocale(inLocale || navigator.language);
+		enyo.updateI18NClasses();
+		originalUpdateLocale();
+	};
+})(enyo.updateLocale);
 
 // we go ahead and run this once during loading of iLib settings are valid
 // during the loads of later libraries.


### PR DESCRIPTION
Now, code that is dependent on the event to fire, will fire when enyo.updateLocale() is executed. Useful for changing the locale after launch or debugging interfaces for multiple languages.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
