### PR TITLE
Update to 20140314-build-5.0-008

### DIFF
--- a/ilib/js/ilib-dyn-full.js
+++ b/ilib/js/ilib-dyn-full.js
@@ -7369,11 +7369,10 @@ ilib.DateFmt.prototype = {
 				id: thisZoneName
 			});
 			
-			var dateOffset = datetz.getOffset(date),
-				fmtOffset = thistz.getOffset(date),
+			var dateOffset = datetz.getOffsetMillis(date)/1000,
+				fmtOffset = thistz.getOffsetMillis(date)/1000,
 				// relative offset in seconds
-				offset = (dateOffset.h || 0)*60*60 + (dateOffset.m || 0)*60 + (dateOffset.s || 0) -
-					((fmtOffset.h || 0)*60*60 + (fmtOffset.m || 0)*60 + (fmtOffset.s || 0));
+				offset = dateOffset - fmtOffset;
 			
 			//console.log("Date offset is " + JSON.stringify(dateOffset));
 			//console.log("Formatter offset is " + JSON.stringify(fmtOffset));

--- a/ilib/js/ilib-dyn-standard.js
+++ b/ilib/js/ilib-dyn-standard.js
@@ -7369,11 +7369,10 @@ ilib.DateFmt.prototype = {
 				id: thisZoneName
 			});
 			
-			var dateOffset = datetz.getOffset(date),
-				fmtOffset = thistz.getOffset(date),
+			var dateOffset = datetz.getOffsetMillis(date)/1000,
+				fmtOffset = thistz.getOffsetMillis(date)/1000,
 				// relative offset in seconds
-				offset = (dateOffset.h || 0)*60*60 + (dateOffset.m || 0)*60 + (dateOffset.s || 0) -
-					((fmtOffset.h || 0)*60*60 + (fmtOffset.m || 0)*60 + (fmtOffset.s || 0));
+				offset = dateOffset - fmtOffset;
 			
 			//console.log("Date offset is " + JSON.stringify(dateOffset));
 			//console.log("Formatter offset is " + JSON.stringify(fmtOffset));


### PR DESCRIPTION
GF-62151,GF-62138: The date formatter now calculates offsets properly between time zones that differ by fractions of an hour. For example, St. John's, Canada has an offset from UTC of -2:30, or Kathmandu, Nepal which has an offset of 5:45 from UTC. Added unit tests to verify the fix.
