### PR TITLE
ENYO-3934: Ensure that browser language's region identifier is formatted correctly.

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -243,8 +243,12 @@ enyo.toUpperCase = function(inString) {
  */
 (function(originalUpdateLocale) {
 	enyo.updateLocale = function(inLocale) {
-		ilib.setLocale(inLocale || navigator.language);
-		$L.setLocale(inLocale || navigator.language);
+		// When using the browser language, ensure that the format is correct (Safari returns lowercase region identifier)
+		inLocale = inLocale || navigator.language.replace(/-[a-z]{2}$/, function (inMatch) {
+			return inMatch.toUpperCase();
+		});
+		ilib.setLocale(inLocale);
+		$L.setLocale(inLocale);
 		enyo.updateI18NClasses();
 		originalUpdateLocale();
 	};


### PR DESCRIPTION
## Issue

In certain browsers such as Safari, the browser-reported language is returned in a format where the region identifier is lowercase, i.e. `en-us`. This causes issues in properly utilizing the default locale for ilib functions.
## Fix

When using the browser language, we properly format the region identifier portion of the string by making it uppercase.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
