### PR TITLE
changed specifying local path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
 	],
 	"license": "apache2",
 	"files": [
-		"./packedbuffer.js",
-		"./zoneinfo.js",
-		"./nodeglue.js",
-		"./ilib/js",
-		"./ilib/locale",
+		"packedbuffer.js",
+		"zoneinfo.js",
+		"nodeglue.js",
+		"ilib/js",
+		"ilib/locale",
 		"README.md"
 	]
 }


### PR DESCRIPTION
In this project, the files are specified with `./` characters on `files field in package.json` 
but `npm install <Local Path>` could not copy those files properly.

So, I raised an issue about this at npm project (https://github.com/npm/npm/issues/6468).
To avoid this issue, those files can be specified without `./` characters.
- Tested on OSX with npm version `1.3.18`,`1.4.14`, `2.1.3`

ps.
In this project, versioning looks strange.
Why don't you use the version format like `major.minor.patch-etc` ?

Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
