### PR TITLE
ENYO-393: Made locale string comparison case-insensitive.

### DIFF
--- a/samples/ChooseLocale.js
+++ b/samples/ChooseLocale.js
@@ -199,8 +199,9 @@ enyo.kind({
     create: function() {
         this.inherited(arguments);
         var curLocale = ilib.getLocale();
-        for(var i = 0; i < this.locales.length; i++)
-            this.$.switcherLocale.createComponent({locale: this.locales[i].locale, content: this.locales[i].locale +" ("+ this.locales[i].label +" / "+ this.locales[i].label_ol +")", active: this.locales[i].locale === curLocale});
+        for(var i = 0; i < this.locales.length; i++) {
+            this.$.switcherLocale.createComponent({locale: this.locales[i].locale, content: this.locales[i].locale +" ("+ this.locales[i].label +" / "+ this.locales[i].label_ol +")", active: this.locales[i].locale.toLowerCase() === curLocale.toLowerCase()});
+        }
     },
 
     setLocale: function(inSender, inEvent) {


### PR DESCRIPTION
### Issue

Safari (in iOS and OSX) reports the locale as a lowercase string, but in our sample we are expecting the region identifier to be uppercase, i.e. `en-US` not `en-us`. This is a known issue with Safari that I filed a bug for (#16457887) on 03/28/2014, as this format does not follow the BCP-47 specification, but which has not yet been addressed or resolved. There was also previous work that attempted to resolve this in `ilib` glue code, but was not a complete solution per the discussion here: https://github.com/enyojs/enyo-ilib/pull/59. All this results in no locale being currently selected, which causes the picker to have a minimal width until a locale is selected.
### Fix

We perform a case-insensitive comparison on the string locale when setting the current locale in the picker, for the samples.
### Notes

Alternatively, we could update `ilib` to always return the properly-cased locale string, but I don't know if this is adding undue overheard and if this is something we want to handle at this layer. This is what was attempted with the original proposed update to the `ilib` glue code.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
