### PR TITLE
ENYO-554: Date TimePicker Samples Locale change poisons entire Sampler (ilib)

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -304,6 +304,10 @@
 			if (enyo.Control) {
 				enyo.Control.prototype.rtl = true;
 			}
+		} else {
+			if (enyo.Control) {
+				enyo.Control.prototype.rtl = false;
+			}
 		}
 
 		// allow enyo or the apps to give CSS classes that are specific to the language, country, or script


### PR DESCRIPTION
### Issue:

enyo-ilib/glue.js was not resetting enyo.Control.prototype.rtl for ltr locales
### Fix:

Set enyo.Control.prototype.rtl = false for ltr locales. Also, call enyo.updateLocale(locale), which is more complete, in the Date/Time Picker Samples instead of ilib.setLocale(locale)

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
