### PR TITLE
Fix bug CCWMP-20941

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -39,7 +39,7 @@
 			
 			// only get the info for this year. Later we can get the info
 			// for any historical or future year too
-			return zif.getIlibZoneInfo(new Date().getFullYear());
+			return zif.getIlibZoneInfo(new Date());
 		} catch (e) {
 			// no file, so just return nothing
 			return undefined;


### PR DESCRIPTION
Time zone files were not being loaded properly because the API for ZoneInfoFile had changed, but the call to it from the glue code hadn't. Now they are in sync and it works as it should.
