### PR TITLE
ENYO-1325: Fixes for language loading problem

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -417,8 +417,8 @@ enyo.toUpperCase = function(inString) {
 	enyo.updateLocale = function(inLocale) {
 		// blow away the cache to force it to reload the manifest files for the new app
 		if (ilib._load) ilib._load.manifest = undefined;
-		ilib.setLocale(inLocale || navigator.language);
-		$L.setLocale(inLocale || navigator.language);
+		ilib.setLocale(inLocale || ilib.getLocale());
+		$L.setLocale(inLocale || ilib.getLocale());
 		enyo.updateI18NClasses();
 		originalUpdateLocale();
 	};


### PR DESCRIPTION
Problem
---
* Android L
* Updated new android system webview 40
* Found in Watch Manager
* Menu always shows in English even user set language Korean

Cause
---
* Android webview return format of navigator.language doesn't follow BCP-47 eg. It was "ko-KR" but now it returns "ko-kr" 
* Related Link - https://code.google.com/p/chromium/issues/detail?id=454331

Solution
---
* As per i18n(Edwin) team's guide, glue.js should call ilib.setLocale with Ilib.getLocale() information, not navigator.language

Enyo-DCO-1.1-Signed-off-by: Seungho Park <seunghoh.park@lge.com>
