### PR TITLE
Fixes ENYO-1876

### DIFF
--- a/lib/glue.js
+++ b/lib/glue.js
@@ -374,7 +374,9 @@ module.exports = function (ilib) {
 	function setLocale (spec) {
 		var locale = new ilib.Locale(spec);
 		if (!resBundle || spec !== resBundle.getLocale().getSpec()) {
-			resBundle = new ilib.ResBundle({
+			// Exporting the ResBundle on $L for compatibility but a better design is needed than
+			// decorating an export from another library. - ryanjduffy
+			resBundle = i18n.$L.rb = new ilib.ResBundle({
 				locale: locale,
 				type: "html",
 				name: "strings",


### PR DESCRIPTION
## Issue
Apps are relying on $L.rb for string formatting but it was removed in the refactoring of $L

## Fix
Restore ResBundle export to $L

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)