### PR TITLE
ENYO-1913: Include ilib locale data in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"ilib/locale",
 		"README.md"
 	],
-	"devAssets": [
+	"assets": [
 		"ilib/locale/**/*.json"
 	]
 }


### PR DESCRIPTION
We were previously omitting ilib locale data from production
builds, on the assumption that it would be provided by some other
means in the production environment.

We will in fact replace the individually bundled locale data in the
webOS production environment, but better to let that happen in the
webOS build process, so that production app builds targeting non-
webOS targets will still have their data where they need it.

(Also, the first pass at the new build scripts for webOS was not
yet providing the locale data so things weren't working properly.)

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)