### PR TITLE
Fixes ENYO-2054

### DIFF
--- a/lib/glue.js
+++ b/lib/glue.js
@@ -451,7 +451,7 @@ function invalidateResources() {
 // during the loads of later libraries.
 i18n.updateLocale(null, true);
 
-return {
+module.exports = {
 	updateI18NClasses: updateI18NClasses,
 	isNonLatinLocale: isNonLatinLocale,
 	invalidateResources: invalidateResources


### PR DESCRIPTION
Correctly export functions from glue.js

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)