### PR TITLE
DRD4TV-1589: The following languages are now re-categorized as latin-based locales

### DIFF
--- a/lib/glue.js
+++ b/lib/glue.js
@@ -259,7 +259,7 @@ enyoLoader.prototype.isAvailable = function(root, path) {
 	// util.print('false\n');
 	return false;
 };
-	
+
 ilib.setLoaderCallback(new enyoLoader());
 
 if (typeof(window.UILocale) !== 'undefined') {
@@ -280,7 +280,7 @@ function isNonLatinLocale (spec) {
 		locale = li.getLocale();
 
     // We use the non-latin fonts for these languages (even though their scripts are technically considered latin)
-    var nonLatinLanguageOverrides = ['bs', 'cs', 'ha', 'hr', 'hu', 'lv', 'lt', 'pl', 'ro', 'sr', 'sl', 'tr', 'vi'];
+    var nonLatinLanguageOverrides = ['ha', 'hu', 'vi'];
     // We use the latin fonts (with non-Latin fallback) for these languages (even though their scripts are non-latin)
     var latinLanguageOverrides = ['ko'];
 	return ((li.getScript() !== 'Latn' || utils.indexOf(locale.getLanguage(), nonLatinLanguageOverrides) !== -1) &&


### PR DESCRIPTION
… due to additional characters added to Miso and Museo Sans: bs (Bosnian), cs (Czech), hr (Croatian), lt (Lithuanian), lv (Latvian), pl (Polish), ro (Romanian), sr (Serbian), sl (Slovenian), and tr (Turkish).

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>