### PR TITLE
Fix for: ENYO-1859

### DIFF
--- a/src/glue.js
+++ b/src/glue.js
@@ -432,8 +432,11 @@ i18n.updateLocale.extend(function (sup) {
 	return function(inLocale) {
 		// blow away the cache to force it to reload the manifest files for the new app
 		if (ilib._load) ilib._load.manifest = undefined;
-		ilib.setLocale(inLocale || ilib.getLocale());
-		setLocale(inLocale || ilib.getLocale());
+		// ilib handles falsy values and automatically uses local locale when encountered which
+		// is expected and desired
+		ilib.setLocale(inLocale);
+		// we supply whatever ilib determined was actually the locale based on what was passed in
+		setLocale(ilib.getLocale());
 		updateI18NClasses();
 		sup.call(this);
 	};


### PR DESCRIPTION
## Issue

Incorrect normalization of incoming parameters had inconsistent and bad results when setting the current locale.

## Fix

Correctly allow ilib to handle falsy values and only update to ilib actually reports the current locale to be so we are never in a mis-matched state.

Tied to these other PR's:

https://github.com/enyojs/enyo-strawman/pull/137
https://github.com/enyojs/moonstone/pull/2531

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)