### PR TITLE
Added check for navigator.language for ie support

### DIFF
--- a/ilib/lib/ilib.js
+++ b/ilib/lib/ilib.js
@@ -242,7 +242,9 @@ ilib.getLocale = function () {
     	switch (plat) {
     		case 'browser':
             	// running in a browser
-                ilib.locale = navigator.language.substring(0,3) + navigator.language.substring(3,5).toUpperCase();  // FF/Opera/Chrome/Webkit
+                if(typeof(navigator.language) !== 'undefined'){
+                    ilib.locale = navigator.language.substring(0,3) + navigator.language.substring(3,5).toUpperCase();  // FF/Opera/Chrome/Webkit
+                }
                 if (!ilib.locale) {
                     // IE on Windows
                     var lang = typeof(navigator.browserLanguage) !== 'undefined' ? 


### PR DESCRIPTION
Reopening because there are no plans to build a new enyo-ilib in 2.7 timeframe.

Matches code changed in https://sourceforge.net/p/i18nlib/code/2062/

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com