### PR TITLE
Add package.json to prevent error during webOS build

### DIFF
--- a/ilib/package.json
+++ b/ilib/package.json
@@ -1,0 +1,73 @@
+{
+    "name": "ilib",
+    "version": "13.2.0",
+    "main": "lib/ilib-node.js",
+    "description": "iLib is a cross-engine library of internationalization (i18n) classes written in pure JS",
+    "keywords": [
+        "internationalization", 
+        "i18n", 
+        "localization", 
+        "l10n", 
+        "globalization", 
+        "g11n",
+        "date",
+        "time",
+        "format",
+        "locale",
+        "translation"
+    ],
+    "homepage": "https://github.com/iLib-js/iLib",
+    "bugs": "https://github.com/iLib-js/iLib/issues",
+    "email": "marketing@translationcircle.com",
+    "license": "Apache-2.0",
+    "licenses": [
+        {
+            "type": "apache2",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ],
+    "author": {
+        "name": "Edwin Hoogerbeets",
+        "web": "http://www.translationcircle.com/",
+        "email": "edwin@translationcircle.com"
+    },
+    "contributors": [
+        {
+            "name": "Edwin Hoogerbeets",
+            "email": "ehoogerbeets@gmail.com" 
+        },
+        {
+            "name": "Goun Lee",
+            "email": "goun.lee@lge.com"
+        },
+        {
+            "name": "Syeonghyup Park",
+            "email": "seonghyup.park@lge.com"
+        }
+    ],
+    "files": [
+        "lib",
+        "locale",
+        "README.md"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:iLib-js/iLib.git"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:iLib-js/iLib.git"
+        }
+    ],
+    "engines": {
+        "ringojs": ">=0.9",
+        "nodejs": ">= 0.10"
+    },
+    "scripts": {
+       "test": "ant test"
+    },
+  "devDependencies": {
+    "http-server": "^0.9.0"
+  }
+}


### PR DESCRIPTION
In webOS, we still support enyo 2.6+. and the latest version of iLib, we use that code as below:
https://github.com/iLib-js/iLib/blob/development/js/lib/ilib.js#L44
```
    if (ilib._dyncode) {
        try {
            var pkg;
            pkg = require("../package.json");
            return pkg.version;
        } catch (e) {
            // ignore
        }
    }
```

But, In enyo-ilib, we don't have that file so it gets an error. At least we need that file to avoid error during webOS build. and I think it needs to be copied properly in enyo bb file in webOS

fyi. Here's error message that I faced
```
ERROR: enyojs-framework-2.6+-0.1.4-r10 do_compile: Function failed: do_compile (log file is located at /jenkins/home/gecko/build-starfish-verify/build/BUILD/work/m16p-starfish-linux-gnueabi/enyojs-framework-2.6+/0.1.4-r10/temp/log.do_compile.21749)
ERROR: Logfile of failure stored in: /jenkins/home/gecko/build-starfish-verify/build/BUILD/work/m16p-starfish-linux-gnueabi/enyojs-framework-2.6+/0.1.4-r10/temp/log.do_compile.21749
Log data follows:
| DEBUG: Executing shell function do_compile
| NOTE: Building: enyo
| NOTE: Building: layout
| NOTE: Building: svg
| NOTE: Building: layout
| NOTE: Building: moonstone
| NOTE: Building: moonstone-extra
| NOTE: Building: enyo-ilib
| {"name":"enyo-dev","hostname":"owl-build","pid":27528,"component":"process-source-stream","level":50,"err":{"message":"could not locate module package","name":"Error","stack":"Error: could not locate module package\n    at module.exports (/jenkins/home/gecko/build-starfish-verify/build/BUILD/sysroots/x86_64-linux/opt/enyo-dev/lib/Packager/lib/process-source-stream/lib/default-resolver.js:51:17)\n    at ProcessSourceStream._resolve (/jenkins/home/gecko/build-starfish-verify/build/BUILD/sysroots/x86_64-linux/opt/enyo-dev/lib/Packager/lib/process-source-stream/index.js:157:2)\n    at ProcessSourceStream._dependency (/jenkins/home/gecko/build-starfish-verify/build/BUILD/sysroots/x86_64-linux/opt/enyo-dev/lib/Packager/lib/process-source-
```